### PR TITLE
Fix jpackage runtime jar path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# FocusTimer
+
+This repository contains the FocusTimer application built with JavaFX.
+
+## Building
+
+To build the fat JAR, run:
+
+```bash
+chmod +x gradlew
+./gradlew shadowJar
+```
+
+The resulting `build/libs/FocusTimer-all.jar` can be packaged with `jpackage`.
+
+## GitHub integration
+
+To push your changes, first create a GitHub repository and add it as a remote:
+
+```bash
+git remote add origin https://github.com/USER/REPO.git
+```
+
+Then push the current branch:
+
+```bash
+git push -u origin work
+```
+
+Replace `USER/REPO` with your repository path.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ tasks.withType<JavaCompile> {
 // ShadowJar 설정: 모든 의존성 포함한 fat-jar 생성
 tasks.named<ShadowJar>("shadowJar") {
     archiveBaseName.set("FocusTimer-all")  // 결과물 이름: FocusTimer-all.jar
+    archiveVersion.set("")                 // 버전 번호 제거
     archiveClassifier.set("")              // 분류자 제거
     mergeServiceFiles()                    // JNA 서비스 파일 병합
 

--- a/installer-output/FocusTimer/app/FocusTimer.cfg
+++ b/installer-output/FocusTimer/app/FocusTimer.cfg
@@ -1,5 +1,5 @@
 [Application]
-app.classpath=$APPDIR\FocusTimer-all-1.0.jar
+app.classpath=$APPDIR\FocusTimer-all.jar
 app.mainclass=TimerApp
 
 [JavaOptions]


### PR DESCRIPTION
## Summary
- rename packaged jar so FocusTimer.exe can find it

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e10771d288324886fd4588cdcbca6