### PR TITLE
fix: stabilize active window registration flow

### DIFF
--- a/src/main/java/TimerApp.java
+++ b/src/main/java/TimerApp.java
@@ -359,31 +359,56 @@ public class TimerApp extends Application {
     }
 
     private void registerProcess() {
-        showAlert("등록", "등록할 창을 활성화한 뒤 확인하세요.");
-        new Thread(() -> {
+        showAlert("등록", "확인을 누른 뒤 10초 안에 등록할 창을 활성화하세요.");
+
+        Thread captureThread = new Thread(() -> {
             try {
-                String fx = primaryStage.getTitle(), win;
-                HWND hwnd;
-                do {
-                    hwnd = User32.INSTANCE.GetForegroundWindow();
-                    char[] b = new char[512];
-                    User32.INSTANCE.GetWindowText(hwnd, b, 512);
-                    win = Native.toString(b);
+                String appTitle = primaryStage.getTitle();
+                HWND targetHwnd = null;
+                long deadline = System.currentTimeMillis() + 10_000;
+
+                while (System.currentTimeMillis() < deadline) {
+                    HWND hwnd = User32.INSTANCE.GetForegroundWindow();
+                    char[] titleBuf = new char[512];
+                    User32.INSTANCE.GetWindowText(hwnd, titleBuf, titleBuf.length);
+                    String title = Native.toString(titleBuf);
+
+                    if (!title.isEmpty() && !title.contains(appTitle)) {
+                        targetHwnd = hwnd;
+                        break;
+                    }
                     Thread.sleep(200);
-                } while (win.contains(fx) || win.isEmpty());
+                }
+
+                if (targetHwnd == null) {
+                    Platform.runLater(() -> showAlert("실패", "창 활성화를 감지하지 못했습니다. 다시 시도하세요."));
+                    return;
+                }
 
                 IntByReference pidRef = new IntByReference();
-                User32.INSTANCE.GetWindowThreadProcessId(hwnd, pidRef);
-                HANDLE pr = Kernel32.INSTANCE.OpenProcess(
+                User32.INSTANCE.GetWindowThreadProcessId(targetHwnd, pidRef);
+                HANDLE processHandle = Kernel32.INSTANCE.OpenProcess(
                         Kernel32.PROCESS_QUERY_INFORMATION | Kernel32.PROCESS_VM_READ,
                         false, pidRef.getValue()
                 );
-                char[] buf = new char[512];
-                IntByReference l = new IntByReference(buf.length);
-                Kernel32.INSTANCE.QueryFullProcessImageName(pr, 0, buf, l);
-                Kernel32.INSTANCE.CloseHandle(pr);
-                String full = new String(buf, 0, l.getValue());
-                String exe = full.substring(full.lastIndexOf('\\') + 1);
+
+                if (processHandle == null) {
+                    Platform.runLater(() -> showAlert("실패", "프로세스 정보를 읽을 수 없습니다."));
+                    return;
+                }
+
+                char[] pathBuf = new char[512];
+                IntByReference pathLen = new IntByReference(pathBuf.length);
+                boolean resolved = Kernel32.INSTANCE.QueryFullProcessImageName(processHandle, 0, pathBuf, pathLen);
+                Kernel32.INSTANCE.CloseHandle(processHandle);
+
+                if (!resolved || pathLen.getValue() <= 0) {
+                    Platform.runLater(() -> showAlert("실패", "실행 파일 경로를 읽지 못했습니다."));
+                    return;
+                }
+
+                String fullPath = new String(pathBuf, 0, pathLen.getValue());
+                String exe = fullPath.substring(fullPath.lastIndexOf('\\') + 1);
 
                 Platform.runLater(() -> {
                     if (processes.size() >= 6) {
@@ -395,8 +420,12 @@ public class TimerApp extends Application {
                         saveProcesses();
                     }
                 });
-            } catch (Exception ignored) {}
-        }).start();
+            } catch (Exception e) {
+                Platform.runLater(() -> showAlert("실패", "등록 중 오류가 발생했습니다: " + e.getMessage()));
+            }
+        });
+        captureThread.setDaemon(true);
+        captureThread.start();
     }
 
     private void showStatsWindow() {


### PR DESCRIPTION
### Motivation

- Users reported that activating a target program window did not reliably register it, so the registration flow needed to be more robust when switching focus to another window. 
- The goal is to provide a bounded capture period and clearer failure feedback so users understand why registration may fail. 

### Description

- Updated `src/main/java/TimerApp.java` by reworking `registerProcess()` to show a clearer prompt and then monitor foreground window changes for a bounded 10-second window. 
- The code now captures a `targetHwnd` only when a non-empty title different from the app title is seen, and it resolves the process by PID and full image path before extracting the executable name. 
- Added explicit failure handling and user alerts when no target window is detected, the process handle cannot be opened, or the executable path cannot be read, and preserved the existing duplicate/max-count checks and save behavior. 
- The capture runs in a daemon `Thread` to avoid blocking app termination and uses `Platform.runLater()` for UI interactions. 

### Testing

- Attempted to run unit tests with `./gradlew test`, but execution failed due to a local permission error (`Permission denied`).
- Attempted `bash ./gradlew test` to allow wrapper download, but Gradle distribution download was blocked in this environment (proxy returned `HTTP/1.1 403 Forbidden`), so the test task could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_684e0f6f07d483249d087d180e375800)